### PR TITLE
Cube renamed to Hangar, its type is now {x:number, y:number}[]

### DIFF
--- a/src/hangar/index.tsx
+++ b/src/hangar/index.tsx
@@ -271,13 +271,6 @@ const Container: React.FunctionComponent<{}> = () => {
   }, [threeContext, hovered]);
 
   React.useEffect(() => {
-    if (!threeContext || editMode !== EditMode.Insert) {
-      return;
-    }
-    const canvas = threeContext.gl.domElement;
-  }, [threeContext, editMode]);
-
-  React.useEffect(() => {
     if (hovered && !drag.dragging && drag.prevDragging) {
       const currentCubes = undoable.current(cubes);
       setCubes(

--- a/src/shared/store.ts
+++ b/src/shared/store.ts
@@ -11,12 +11,26 @@ type Point = { x: number; z: number };
 
 export type Cube = Point[];
 
-// export interface Cube {
-//   // x: number;
-//   // z: number;
-//   // wx: number;
-//   // wz: number;
-// }
+interface OldCube {
+  x: number;
+  z: number;
+  wx: number;
+  wz: number;
+}
+
+export const cubeToOldCube = (cube: Cube): OldCube => ({
+  x: cube[0].x,
+  z: cube[0].z,
+  wx: Math.abs(cube[2].x - cube[0].x),
+  wz: Math.abs(cube[2].z - cube[0].z),
+});
+
+export const oldCubeToCube = (oldCube: OldCube): Cube => [
+  { x: oldCube.x, z: oldCube.z },
+  { x: oldCube.x + oldCube.wx, z: oldCube.z },
+  { x: oldCube.x + oldCube.wx, z: oldCube.z + oldCube.wz },
+  { x: oldCube.x, z: oldCube.z + oldCube.wz },
+];
 
 export enum EditMode {
   Move = "Move",

--- a/src/shared/store.ts
+++ b/src/shared/store.ts
@@ -9,27 +9,27 @@ const GRID = grid("m");
 
 type Point = { x: number; z: number };
 
-export type Cube = Point[];
+export type Hangar = Point[];
 
-interface OldCube {
+interface Cube {
   x: number;
   z: number;
   wx: number;
   wz: number;
 }
 
-export const cubeToOldCube = (cube: Cube): OldCube => ({
-  x: cube[0].x,
-  z: cube[0].z,
-  wx: Math.abs(cube[2].x - cube[0].x),
-  wz: Math.abs(cube[2].z - cube[0].z),
+export const hangarToCube = (hangar: Hangar): Cube => ({
+  x: hangar[0].x,
+  z: hangar[0].z,
+  wx: Math.abs(hangar[2].x - hangar[0].x),
+  wz: Math.abs(hangar[2].z - hangar[0].z),
 });
 
-export const oldCubeToCube = (oldCube: OldCube): Cube => [
-  { x: oldCube.x, z: oldCube.z },
-  { x: oldCube.x + oldCube.wx, z: oldCube.z },
-  { x: oldCube.x + oldCube.wx, z: oldCube.z + oldCube.wz },
-  { x: oldCube.x, z: oldCube.z + oldCube.wz },
+export const cubeToHangar = (cube: Cube): Hangar => [
+  { x: cube.x, z: cube.z },
+  { x: cube.x + cube.wx, z: cube.z },
+  { x: cube.x + cube.wx, z: cube.z + cube.wz },
+  { x: cube.x, z: cube.z + cube.wz },
 ];
 
 export enum EditMode {
@@ -41,7 +41,7 @@ export enum EditMode {
 
 export interface State {
   editMode: EditMode;
-  cubes: undoable.Undoable<Array<Cube>>;
+  cubes: undoable.Undoable<Array<Hangar>>;
   grid: {
     properties: {
       color: string;

--- a/src/shared/store.ts
+++ b/src/shared/store.ts
@@ -152,6 +152,8 @@ api.getState().set((state: State) => {
   };
 });
 
+window["api"] = api;
+
 // rudimentarily save state to localStorage if grid.occupiedCells changes
 
 api.subscribe(

--- a/src/shared/store.ts
+++ b/src/shared/store.ts
@@ -7,12 +7,16 @@ import grid from "./grid";
 
 const GRID = grid("m");
 
-export interface Cube {
-  x: number;
-  z: number;
-  wx: number;
-  wz: number;
-}
+type Point = { x: number; z: number };
+
+export type Cube = Point[];
+
+// export interface Cube {
+//   // x: number;
+//   // z: number;
+//   // wx: number;
+//   // wz: number;
+// }
 
 export enum EditMode {
   Move = "Move",
@@ -99,12 +103,18 @@ export const [useStore, api] = create(
     },
     editMode: EditMode.Move,
     cubes: undoable.create([
-      {
-        x: 0,
-        z: 0,
-        wx: GRID.x,
-        wz: GRID.z,
-      },
+      // {
+      //   x: 0,
+      //   z: 0,
+      //   wx: GRID.x,
+      //   wz: GRID.z,
+      // }
+      [
+        { x: 0, z: 0 },
+        { x: GRID.x, z: 0 },
+        { x: GRID.x, z: GRID.z },
+        { x: 0, z: GRID.z },
+      ],
     ]),
     set: (fn) => set(produce(fn)),
   }))


### PR DESCRIPTION
I'll explain in the morning but take a look at the code. This is quite a big refactoring.

I've kept the Cube interface in the code as this makes it easier to understand what's happened. Basically a Hangar is now a closed polygon array of {x,y} points.

This should give us some flexibility if the shape needs to be more dynamic when we start splitting faces.

These lines from store might help to explain the new situation -

```typescript
type Point = { x: number; z: number };

export type Hangar = Point[];

// keeping the old interface during the refactor

interface Cube {
  x: number;
  z: number;
  wx: number;
  wz: number;
}

// helper methods during the refactor

export const hangarToCube = (hangar: Hangar): Cube => ({
  x: hangar[0].x,
  z: hangar[0].z,
  wx: Math.abs(hangar[2].x - hangar[0].x),
  wz: Math.abs(hangar[2].z - hangar[0].z),
});

export const cubeToHangar = (cube: Cube): Hangar => [
  { x: cube.x, z: cube.z }, // original x and z coordinates
  { x: cube.x + cube.wx, z: cube.z },
  { x: cube.x + cube.wx, z: cube.z + cube.wz },
  { x: cube.x, z: cube.z + cube.wz },
];
```

for now I expect that a Hangar will always be an array of 4 points but at least we have the flexibility to change should we need to.